### PR TITLE
fix #46: Translate Core/DefInjected/WorkTypeDef/WorkTypes.xml

### DIFF
--- a/Core/DefInjected/WorkTypeDef/WorkTypes.xml
+++ b/Core/DefInjected/WorkTypeDef/WorkTypes.xml
@@ -1,224 +1,224 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
-  
+
   <!-- EN: Create beautiful works of art from raw materials. -->
-  <Art.description>TODO</Art.description>
+  <Art.description>Тварыць мастацтва з неапрацаваных матэрыялаў.</Art.description>
   <!-- EN: art -->
-  <Art.gerundLabel>TODO</Art.gerundLabel>
+  <Art.gerundLabel>мастацтва</Art.gerundLabel>
   <!-- EN: art -->
-  <Art.labelShort>TODO</Art.labelShort>
+  <Art.labelShort>тварыць</Art.labelShort>
   <!-- EN: Artist -->
-  <Art.pawnLabel>TODO</Art.pawnLabel>
+  <Art.pawnLabel>Мастак</Art.pawnLabel>
   <!-- EN: Do art at -->
-  <Art.verb>TODO</Art.verb>
-  
+  <Art.verb>Тварыць мастацтва на</Art.verb><!-- ...на стале мастака -->
+
   <!-- EN: Unskilled and easy tasks. Release prisoners and flick switches on machines. -->
-  <BasicWorker.description>TODO</BasicWorker.description>
+  <BasicWorker.description>Выконваць простыя заданні, якія не патрабуюць навыкаў, напрыклад: вызваляць зняволеных і пстрыкаць пераключальнікі на машынах.</BasicWorker.description>
   <!-- EN: dealing with -->
-  <BasicWorker.gerundLabel>TODO</BasicWorker.gerundLabel>
+  <BasicWorker.gerundLabel>некваліфікаваная праца</BasicWorker.gerundLabel>
   <!-- EN: basic -->
-  <BasicWorker.labelShort>TODO</BasicWorker.labelShort>
+  <BasicWorker.labelShort>працаваць</BasicWorker.labelShort><!-- Лепш ўдакладніць, але больш тэкста не ўлезе ў надпіс -->
   <!-- EN: Worker -->
-  <BasicWorker.pawnLabel>TODO</BasicWorker.pawnLabel>
+  <BasicWorker.pawnLabel>Працаўнік</BasicWorker.pawnLabel>
   <!-- EN: Deal with -->
-  <BasicWorker.verb>TODO</BasicWorker.verb>
-  
+  <BasicWorker.verb>Працаваць з</BasicWorker.verb><!-- ...з аб'ектам/пабудовай/істотай -->
+
   <!-- EN: Clear snow, pollution and clean the floor in the home area. -->
-  <Cleaning.description>TODO</Cleaning.description>
+  <Cleaning.description>Прыбіраць снег, забруджванне і падлогі ў хатняй вобласці.</Cleaning.description>
   <!-- EN: cleaning -->
-  <Cleaning.gerundLabel>TODO</Cleaning.gerundLabel>
+  <Cleaning.gerundLabel>прыбіранне</Cleaning.gerundLabel>
   <!-- EN: clean -->
-  <Cleaning.labelShort>TODO</Cleaning.labelShort>
+  <Cleaning.labelShort>прыбіраць</Cleaning.labelShort>
   <!-- EN: Cleaner -->
-  <Cleaning.pawnLabel>TODO</Cleaning.pawnLabel>
+  <Cleaning.pawnLabel>Прыбіральшчык</Cleaning.pawnLabel>
   <!-- EN: Clean -->
-  <Cleaning.verb>TODO</Cleaning.verb>
-  
+  <Cleaning.verb>Прыбіраць</Cleaning.verb>
+
   <!-- EN: Build things that you've designated, and fix damaged or broken-down buildings. -->
-  <Construction.description>TODO</Construction.description>
+  <Construction.description>Будаваць усё, што вы прызначаеце, рэмантаваць пашкоджаныя і аднаўляць зруйнаваныя пабудовы.</Construction.description>
   <!-- EN: constructing -->
-  <Construction.gerundLabel>TODO</Construction.gerundLabel>
+  <Construction.gerundLabel>будаўніцтва</Construction.gerundLabel>
   <!-- EN: construct -->
-  <Construction.labelShort>TODO</Construction.labelShort>
+  <Construction.labelShort>будаваць</Construction.labelShort>
   <!-- EN: Constructor -->
-  <Construction.pawnLabel>TODO</Construction.pawnLabel>
+  <Construction.pawnLabel>Будаўнік</Construction.pawnLabel>
   <!-- EN: Construct -->
-  <Construction.verb>TODO</Construction.verb>
-  
+  <Construction.verb>Будаваць</Construction.verb>
+
   <!-- EN: Prepare meals and butcher meat. -->
-  <Cooking.description>TODO</Cooking.description>
+  <Cooking.description>Гатаваць стравы і разбіраць тушы на мяса.</Cooking.description>
   <!-- EN: cooking -->
-  <Cooking.gerundLabel>TODO</Cooking.gerundLabel>
+  <Cooking.gerundLabel>гатаванне</Cooking.gerundLabel>
   <!-- EN: cook -->
-  <Cooking.labelShort>TODO</Cooking.labelShort>
+  <Cooking.labelShort>гатаваць</Cooking.labelShort>
   <!-- EN: Cook -->
-  <Cooking.pawnLabel>TODO</Cooking.pawnLabel>
+  <Cooking.pawnLabel>Кухар</Cooking.pawnLabel>
   <!-- EN: Cook -->
-  <Cooking.verb>TODO</Cooking.verb>
-  
+  <Cooking.verb>Гатаваць</Cooking.verb>
+
   <!-- EN: Do general low-skilled labor at work stations. This includes stonecutting, smelting, and more. -->
-  <Crafting.description>TODO</Crafting.description>
+  <Crafting.description>Займацца агульнай нізкакваліфікаванай працай на рабочых станцыях, напрыклад: рэзкай камянёў, плаўленнем металаў і г.д.</Crafting.description>
   <!-- EN: crafting -->
-  <Crafting.gerundLabel>TODO</Crafting.gerundLabel>
+  <Crafting.gerundLabel>рамяство</Crafting.gerundLabel>
   <!-- EN: craft -->
-  <Crafting.labelShort>TODO</Crafting.labelShort>
+  <Crafting.labelShort>вырабляць</Crafting.labelShort>
   <!-- EN: Crafter -->
-  <Crafting.pawnLabel>TODO</Crafting.pawnLabel>
+  <Crafting.pawnLabel>Рамеснік</Crafting.pawnLabel>
   <!-- EN: Craft at -->
-  <Crafting.verb>TODO</Crafting.verb>
-  
+  <Crafting.verb>Вырабляць у/на</Crafting.verb><!-- ...на стале для чагосьці, ...у плавільні -->
+
   <!-- EN: Treat the sick, bring them food, cheer them up, and perform assigned surgeries. Doctors will care for both colonists and prisoners. -->
-  <Doctor.description>TODO</Doctor.description>
+  <Doctor.description>Лячыць і падбадзёрваць хворых, прыносіць ім ежу, выконваць прызначаныя хірургічныя аперацыі. Лекары будуць клапаціцца як аб сяленцах, так і аб зняволеных.</Doctor.description>
   <!-- EN: doctoring -->
-  <Doctor.gerundLabel>TODO</Doctor.gerundLabel>
+  <Doctor.gerundLabel>Аказанне медыцынскай дапамогі</Doctor.gerundLabel><!-- Не выкарыстаў пераклад "лячэнне", каб не блытацца з patienting -->
   <!-- EN: doctor -->
-  <Doctor.labelShort>TODO</Doctor.labelShort>
+  <Doctor.labelShort>лячыць</Doctor.labelShort>
   <!-- EN: Doctor -->
-  <Doctor.pawnLabel>TODO</Doctor.pawnLabel>
+  <Doctor.pawnLabel>Лекар</Doctor.pawnLabel>
   <!-- EN: Care for -->
-  <Doctor.verb>TODO</Doctor.verb>
-  
+  <Doctor.verb>Лячыць</Doctor.verb><!-- ...кагосьці -->
+
   <!-- EN: Extinguish fires in the colony. -->
-  <Firefighter.description>TODO</Firefighter.description>
+  <Firefighter.description>Гасіць пажары ў селішчы.</Firefighter.description>
   <!-- EN: firefighting -->
-  <Firefighter.gerundLabel>TODO</Firefighter.gerundLabel>
+  <Firefighter.gerundLabel>гашэнне пажараў</Firefighter.gerundLabel>
   <!-- EN: firefight -->
-  <Firefighter.labelShort>TODO</Firefighter.labelShort>
+  <Firefighter.labelShort>гасіць</Firefighter.labelShort>
   <!-- EN: Firefighter -->
-  <Firefighter.pawnLabel>TODO</Firefighter.pawnLabel>
+  <Firefighter.pawnLabel>Пажарнік</Firefighter.pawnLabel>
   <!-- EN: Extinguish -->
-  <Firefighter.verb>TODO</Firefighter.verb>
-  
+  <Firefighter.verb>Гасіць</Firefighter.verb>
+
   <!-- EN: Plant seeds, harvest crops, and forage for wild plants. -->
-  <Growing.description>TODO</Growing.description>
+  <Growing.description>Засейваць зерне, збіраць ураджай і дзікія расліны.</Growing.description>
   <!-- EN: growing -->
-  <Growing.gerundLabel>TODO</Growing.gerundLabel>
+  <Growing.gerundLabel>раслінаводства</Growing.gerundLabel>
   <!-- EN: grow -->
-  <Growing.labelShort>TODO</Growing.labelShort>
+  <Growing.labelShort>вырашчваць</Growing.labelShort>
   <!-- EN: Grower -->
-  <Growing.pawnLabel>TODO</Growing.pawnLabel>
+  <Growing.pawnLabel>Раслінавод</Growing.pawnLabel>
   <!-- EN: Grow -->
-  <Growing.verb>TODO</Growing.verb>
-  
+  <Growing.verb>Вырашчваць</Growing.verb>
+
   <!-- EN: Tame, train, harvest resources from and slaughter animals. -->
-  <Handling.description>TODO</Handling.description>
+  <Handling.description>Прыручаць і дрэсіраваць жывёл, рэзаць іх на мяса і збіраць з іх рэсурсы.</Handling.description>
   <!-- EN: handling -->
-  <Handling.gerundLabel>TODO</Handling.gerundLabel>
+  <Handling.gerundLabel>гадаванне жывёл</Handling.gerundLabel>
   <!-- EN: handle -->
-  <Handling.labelShort>TODO</Handling.labelShort>
+  <Handling.labelShort>гадаваць</Handling.labelShort>
   <!-- EN: Handler -->
-  <Handling.pawnLabel>TODO</Handling.pawnLabel>
+  <Handling.pawnLabel>Жывёлагадовец</Handling.pawnLabel>
   <!-- EN: Handle -->
-  <Handling.verb>TODO</Handling.verb>
-  
+  <Handling.verb>Гадаваць жывёл</Handling.verb>
+
   <!-- EN: Carry things to where they need to be. -->
-  <Hauling.description>TODO</Hauling.description>
+  <Hauling.description>Насіць рэчы ў тыя месцы, дзе яны павінны знаходзіцца.</Hauling.description>
   <!-- EN: hauling -->
-  <Hauling.gerundLabel>TODO</Hauling.gerundLabel>
+  <Hauling.gerundLabel>нашэнне</Hauling.gerundLabel>
   <!-- EN: haul -->
-  <Hauling.labelShort>TODO</Hauling.labelShort>
+  <Hauling.labelShort>насіць</Hauling.labelShort>
   <!-- EN: Hauler -->
-  <Hauling.pawnLabel>TODO</Hauling.pawnLabel>
+  <Hauling.pawnLabel>Насільшчык</Hauling.pawnLabel>
   <!-- EN: Haul -->
-  <Hauling.verb>TODO</Hauling.verb>
-  
+  <Hauling.verb>Насіць</Hauling.verb>
+
   <!-- EN: Kill animals which are designated to be hunted. -->
-  <Hunting.description>TODO</Hunting.description>
+  <Hunting.description>Забіваць жывёл, якія выбраны для палявання.</Hunting.description>
   <!-- EN: hunting -->
-  <Hunting.gerundLabel>TODO</Hunting.gerundLabel>
+  <Hunting.gerundLabel>паляванне</Hunting.gerundLabel>
   <!-- EN: hunt -->
-  <Hunting.labelShort>TODO</Hunting.labelShort>
+  <Hunting.labelShort>паляваць</Hunting.labelShort>
   <!-- EN: Hunter -->
-  <Hunting.pawnLabel>TODO</Hunting.pawnLabel>
+  <Hunting.pawnLabel>Паляўнічы</Hunting.pawnLabel>
   <!-- EN: Hunt -->
-  <Hunting.verb>TODO</Hunting.verb>
-  
+  <Hunting.verb>Паляваць</Hunting.verb>
+
   <!-- EN: Digging and drilling. -->
-  <Mining.description>TODO</Mining.description>
+  <Mining.description>Капанне і бурэнне.</Mining.description>
   <!-- EN: mining -->
-  <Mining.gerundLabel>TODO</Mining.gerundLabel>
+  <Mining.gerundLabel>шахцёрства</Mining.gerundLabel>
   <!-- EN: mine -->
-  <Mining.labelShort>TODO</Mining.labelShort>
+  <Mining.labelShort>здабываць</Mining.labelShort>
   <!-- EN: Miner -->
-  <Mining.pawnLabel>TODO</Mining.pawnLabel>
+  <Mining.pawnLabel>Шахцёр</Mining.pawnLabel>
   <!-- EN: Mine -->
-  <Mining.verb>TODO</Mining.verb>
-  
+  <Mining.verb>Здабываць</Mining.verb>
+
   <!-- EN: Go to a medical bed for treatment if you have an immediately life-threatening health condition. -->
-  <Patient.description>TODO</Patient.description>
+  <Patient.description>Легчы ў медыцынскі ложак, каб лячыцца ад хвароб, якія пагражаюць жыццю і патрабуюць неадкладнага медыцынскага ўмяшання.</Patient.description>
   <!-- EN: patienting -->
-  <Patient.gerundLabel>TODO</Patient.gerundLabel>
+  <Patient.gerundLabel>лячэнне</Patient.gerundLabel>
   <!-- EN: patient -->
-  <Patient.labelShort>TODO</Patient.labelShort>
+  <Patient.labelShort>лячыцца</Patient.labelShort>
   <!-- EN: Patient -->
-  <Patient.pawnLabel>TODO</Patient.pawnLabel>
+  <Patient.pawnLabel>Пацыент</Patient.pawnLabel>
   <!-- EN: Become patient -->
-  <Patient.verb>TODO</Patient.verb>
-  
+  <Patient.verb>Лячыцца</Patient.verb>
+
   <!-- EN: Rest in bed to recuperate from not-immediately-life-threatening medical problems. -->
-  <PatientBedRest.description>TODO</PatientBedRest.description>
+  <PatientBedRest.description>Адпачываць у ложку, каб ачуньваць ад хвароб, якія не пагражаюць жыццю і не патрабуюць неадкладнага медыцынскага ўмяшання.</PatientBedRest.description>
   <!-- EN: resting in bed -->
-  <PatientBedRest.gerundLabel>TODO</PatientBedRest.gerundLabel>
+  <PatientBedRest.gerundLabel>ачуньванне ў ложку</PatientBedRest.gerundLabel>
   <!-- EN: bed rest -->
-  <PatientBedRest.labelShort>TODO</PatientBedRest.labelShort>
+  <PatientBedRest.labelShort>ачуньваць</PatientBedRest.labelShort>
   <!-- EN: Bed rester -->
-  <PatientBedRest.pawnLabel>TODO</PatientBedRest.pawnLabel>
+  <PatientBedRest.pawnLabel>Ачуньваючы</PatientBedRest.pawnLabel><!-- Такія формы не характэрны для беларускай мовы, але ж тут лепш выкарыстаць як мага кароткае слова -->
   <!-- EN: Become patient -->
-  <PatientBedRest.verb>TODO</PatientBedRest.verb>
-  
+  <PatientBedRest.verb>Ачуньваць</PatientBedRest.verb><!-- Пры літаральным перакладзе можна пераблытаць гэты радок з такім жа вышэй, таму выбраў вольны пераклад -->
+
   <!-- EN: Cut or harvest plants as designated. -->
-  <PlantCutting.description>TODO</PlantCutting.description>
+  <PlantCutting.description>Зрэзваць, секчы або пажынаць прызначаныя расліны.</PlantCutting.description><!-- cut = зрэзваць расліны, сячы дрэвы -->
   <!-- EN: plant cutting -->
-  <PlantCutting.gerundLabel>TODO</PlantCutting.gerundLabel>
+  <PlantCutting.gerundLabel>лесаводства</PlantCutting.gerundLabel>
   <!-- EN: plant cut -->
-  <PlantCutting.labelShort>TODO</PlantCutting.labelShort>
+  <PlantCutting.labelShort>зрэзваць</PlantCutting.labelShort>
   <!-- EN: Plant cutter -->
-  <PlantCutting.pawnLabel>TODO</PlantCutting.pawnLabel>
+  <PlantCutting.pawnLabel>Лесавод</PlantCutting.pawnLabel>
   <!-- EN: Cut -->
-  <PlantCutting.verb>TODO</PlantCutting.verb>
-  
+  <PlantCutting.verb>Зрэзваць/секчы</PlantCutting.verb>
+
   <!-- EN: Perform research work. -->
-  <Research.description>TODO</Research.description>
+  <Research.description>Выконваць даследчыя работы.</Research.description>
   <!-- EN: researching -->
-  <Research.gerundLabel>TODO</Research.gerundLabel>
+  <Research.gerundLabel>даследаванне</Research.gerundLabel>
   <!-- EN: research -->
-  <Research.labelShort>TODO</Research.labelShort>
+  <Research.labelShort>вывучаць</Research.labelShort><!-- Лагічны пераклад "даследаваць" не ўлазіць у подпіс, выкарыстаў сінонім -->
   <!-- EN: Researcher -->
-  <Research.pawnLabel>TODO</Research.pawnLabel>
+  <Research.pawnLabel>Даследчык</Research.pawnLabel>
   <!-- EN: Research at -->
-  <Research.verb>TODO</Research.verb>
-  
+  <Research.verb>Даследаваць на</Research.verb><!-- ...на стале для даследаванняў -->
+
   <!-- EN: Create weapons and tools from raw materials, either as a blacksmith or by machining. Also repair mechanoids, if the colonist is a mechanitor. -->
-  <Smithing.description>TODO</Smithing.description>
+  <Smithing.description>Ствараць зброю і прылады з неапрацаваных матэрыялаў у кавальні або з дапамогай механічнай апрацоўкі; таксама рэмантаваць механоідаў, калі сяленец з'яўляецца механітарам.</Smithing.description>
   <!-- EN: smithing -->
-  <Smithing.gerundLabel>TODO</Smithing.gerundLabel>
+  <Smithing.gerundLabel>каванне</Smithing.gerundLabel>
   <!-- EN: smith -->
-  <Smithing.labelShort>TODO</Smithing.labelShort>
+  <Smithing.labelShort>каваць</Smithing.labelShort>
   <!-- EN: Smith -->
-  <Smithing.pawnLabel>TODO</Smithing.pawnLabel>
+  <Smithing.pawnLabel>Каваль</Smithing.pawnLabel>
   <!-- EN: Smith at -->
-  <Smithing.verb>TODO</Smithing.verb>
-  
+  <Smithing.verb>Каваць ў/на</Smithing.verb><!-- ...у кавальні, ...на варштаце -->
+
   <!-- EN: Create apparel from raw materials. -->
-  <Tailoring.description>TODO</Tailoring.description>
+  <Tailoring.description>Ствараць адзенне з неапрацаваных матэрыялаў.</Tailoring.description>
   <!-- EN: tailoring -->
-  <Tailoring.gerundLabel>TODO</Tailoring.gerundLabel>
+  <Tailoring.gerundLabel>кравецтва</Tailoring.gerundLabel>
   <!-- EN: tailor -->
-  <Tailoring.labelShort>TODO</Tailoring.labelShort>
+  <Tailoring.labelShort>шыць</Tailoring.labelShort>
   <!-- EN: Tailor -->
-  <Tailoring.pawnLabel>TODO</Tailoring.pawnLabel>
+  <Tailoring.pawnLabel>Кравец</Tailoring.pawnLabel>
   <!-- EN: Tailor at -->
-  <Tailoring.verb>TODO</Tailoring.verb>
-  
+  <Tailoring.verb>Шыць на</Tailoring.verb><!-- ...на месцы для вырабу, ...на кравецкім стале -->
+
   <!-- EN: Manage, feed, chat with, and recruit prisoners. -->
-  <Warden.description>TODO</Warden.description>
+  <Warden.description>Кіраваць зняволенымі, харчаваць і вербаваць іх, размаўляць з імі.</Warden.description>
   <!-- EN: wardening -->
-  <Warden.gerundLabel>TODO</Warden.gerundLabel>
+  <Warden.gerundLabel>нагляд</Warden.gerundLabel>
   <!-- EN: warden -->
-  <Warden.labelShort>TODO</Warden.labelShort>
+  <Warden.labelShort>наглядаць</Warden.labelShort>
   <!-- EN: Warden -->
-  <Warden.pawnLabel>TODO</Warden.pawnLabel>
+  <Warden.pawnLabel>Наглядчык</Warden.pawnLabel>
   <!-- EN: Handle -->
-  <Warden.verb>TODO</Warden.verb>
-  
+  <Warden.verb>Наглядаць</Warden.verb>
+
 </LanguageData>


### PR DESCRIPTION
Пратэсціравана на Linux-версіі гульні (1.4.3704 Core + Biotech + Ideology + Royalty), 1920x1080.

Пакрытыкуйце, калі ласка. Некаторыя спрэчныя моманты патлумачыў у каментах. Але ж не ўсё атрымалася перакласці дакладна ў асноўным з-за абмежаванняў па месцу ў подпісах. Асабліва гэта датычыцца вось гэтага меню:
![image](https://github.com/Ludeon/RimWorld-Belarusian/assets/16258951/259d177b-e659-4e9c-94e0-81277357a3b1)